### PR TITLE
Fix JotL card images not rendering in Docker

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,7 @@ const nextConfig: NextConfig = {
   assetPrefix: basePath || undefined,
   images: {
     minimumCacheTTL: 60 * 60 * 24 * 30,
+    unoptimized: true,
   },
   experimental: {
     reactCompiler: true,

--- a/src/app/(selectClass)/ClassSelection.tsx
+++ b/src/app/(selectClass)/ClassSelection.tsx
@@ -19,7 +19,15 @@ export default function ClassSelection({
   return (
     <div className='flex flex-col gap-16 p-16 place-items-center'>
       <header className='flex flex-col items-center gap-4'>
-        <Image priority loading='eager' src={logo} alt={`${game} logo`} width={600} height={87} />
+        <Image
+          priority
+          loading='eager'
+          src={logo}
+          alt={`${game} logo`}
+          width={600}
+          height={161}
+          unoptimized
+        />
         <GameSelector />
       </header>
       <h1 className='text-2xl font-bold text-center text-black hidden'>Select your class</h1>

--- a/src/app/_components/cards/Card.tsx
+++ b/src/app/_components/cards/Card.tsx
@@ -90,6 +90,7 @@ export function CardComponent<X extends Card>({
           alt={`card ${card.name}`}
           width={143}
           height={200}
+          unoptimized
         />
       </button>
       {onCloseCard && <button

--- a/src/app/_components/class/ClassIcon.tsx
+++ b/src/app/_components/class/ClassIcon.tsx
@@ -14,5 +14,6 @@ export default function ClassIcon({
     src={path}
     alt={name}
     {...iconSize}
+    unoptimized
   />;
 }


### PR DESCRIPTION
## Summary
- Disable Next.js image optimization globally so Jaws of the Lion assets load directly from the `public` folder
- Adjust JotL logo dimensions to preserve its aspect ratio

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a90c84c8348333969892fc18f2ee6a