### PR TITLE
Fix JotL image paths and add class icon fallback

### DIFF
--- a/src/app/(selectClass)/ClassSelection.tsx
+++ b/src/app/(selectClass)/ClassSelection.tsx
@@ -15,7 +15,8 @@ export default function ClassSelection({
 }) {
   const game = useGameStore((s) => s.game);
   const classes = game === 'Jaws of the Lion' ? jotlClasses : frosthavenClasses;
-  const logo = game === 'Jaws of the Lion' ? '/jotl/jotl-logo.webp' : '/fh-frosthaven-logo.webp';
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+  const logo = `${basePath}${game === 'Jaws of the Lion' ? '/jotl/jotl-logo.webp' : '/fh-frosthaven-logo.webp'}`;
   return (
     <div className='flex flex-col gap-16 p-16 place-items-center'>
       <header className='flex flex-col items-center gap-4'>

--- a/src/app/_components/cards/Card.tsx
+++ b/src/app/_components/cards/Card.tsx
@@ -26,6 +26,7 @@ export function CardComponent<X extends Card>({
   const innerRef = useRef<HTMLDivElement>(null);
   const [isActionWheelOpen, setIsActionWheelOpen] = useState(false);
   const [hasImageError, setHasImageError] = useState(false);
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
 
   const onClickCard = () => {
     if (actions.length === 0) return;
@@ -92,7 +93,7 @@ export function CardComponent<X extends Card>({
           : <Image
               className='shadow-card shadow-gray-950/80'
               {...(mapName ? { useMap: `#${mapName}` } : {})}
-              src={card.path}
+              src={`${basePath}${card.path}`}
               alt={`card ${card.name}`}
               width={143}
               height={200}

--- a/src/app/_components/class/ClassIcon.tsx
+++ b/src/app/_components/class/ClassIcon.tsx
@@ -2,6 +2,7 @@
 import type { Card } from '@/domain/cards.type';
 import type { FrosthavenClass } from '@/domain/frosthaven-class.type';
 import Image from 'next/image';
+import { useState } from 'react';
 
 export default function ClassIcon({
   fhClass,
@@ -9,11 +10,22 @@ export default function ClassIcon({
   fhClass: FrosthavenClass<Card>;
 }) {
   const { name, path, iconSize } = fhClass;
+  const [hasError, setHasError] = useState(false);
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+
+  if (hasError) {
+    return <div
+      className='max-w-icon max-h-icon flex items-center justify-center bg-white text-xs text-black border border-solid border-gray-400'
+      style={{ width: iconSize.width, height: iconSize.height }}
+    >{name}</div>;
+  }
+
   return <Image
     className='max-w-icon max-h-icon'
-    src={path}
+    src={`${basePath}${path}`}
     alt={name}
     {...iconSize}
     unoptimized
+    onError={() => setHasError(true)}
   />;
 }


### PR DESCRIPTION
## Summary
- prefix static asset paths with `NEXT_PUBLIC_BASE_PATH` so JotL logos and card images resolve correctly
- add error fallback for class icons and use base path for ability cards

## Testing
- `npm run lint`
- `curl -I http://localhost:3000/jotl/voidwarden/icon.webp`
- `curl -I http://localhost:3000/jotl/voidwarden/abilities/jl-black-boon.png`


------
https://chatgpt.com/codex/tasks/task_e_68a962b8f33c8333a7e5426226690101